### PR TITLE
change docker in multi-stage mode to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG IMAGE=intersystems/iris:2019.1.0S.111.0
 ARG IMAGE=store/intersystems/iris-community:2019.3.0.309.0
 ARG IMAGE=store/intersystems/iris-community:2019.4.0.379.0
 ARG IMAGE=intersystemsdc/iris-community
-FROM $IMAGE
+FROM $IMAGE as builder
 
 USER root   
 ## add git
@@ -21,3 +21,11 @@ COPY iris.script iris.script
 RUN iris start IRIS \
 	&& iris session IRIS < iris.script \
     && iris stop IRIS quietly
+
+FROM $IMAGE as final
+
+ADD --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} https://github.com/grongierisc/iris-docker-multi-stage-script/releases/latest/download/copy-data.py /irisdev/app/copy-data.py
+
+RUN --mount=type=bind,source=/,target=/builder/root,from=builder \
+    cp -f /builder/root/usr/irissys/iris.cpf /usr/irissys/iris.cpf && \
+    python3 /irisdev/app/copy-data.py -c /usr/irissys/iris.cpf -d /builder/root/ 


### PR DESCRIPTION
before 
 objectscript-package-template-iris-1   791MB (virtual 3.72GB)
after
  objectscript-package-template-iris-1   791MB (virtual 3.05GB)